### PR TITLE
Added a form component and how to use it in the dummy documentation page

### DIFF
--- a/app/components/materialize-form.js
+++ b/app/components/materialize-form.js
@@ -1,0 +1,43 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  inputs: [{input: "First Name", isText: true}, {input: "Last Name", isText: true}, {input: "Email", isText: true}, {input: "Phone Number", isText: true},
+           {input: "Male", isRadio: true}, {input: "Female", isRadio: true}, {input: "Like Beer?", isSwitch: true, on: "Yes", off: "No"}, {input: "How Much?", isRange: true},
+           {input: "IPAs", isCheckBox: true}, {input: "Blondes", isCheckBox: true}, {input: "Light Beers", isCheckBox: true}, {input: "Lagers", isCheckBox: true},
+           {input: "When did you last have a tasty Beverage?", isDate: true, years: 1},
+           {input: "Would you rather eat", isSelect: true, selections: [{value: 1, option: 'BBQ'}, {value: 2, option: 'Italian'}, {value: 3, option: 'Burgers'}]}],
+
+
+  ids: [],
+  tagName: 'div',
+  didInsertElement: function(){
+    this.$('.datepicker').pickadate({
+      selectMonths: true,
+      selectYears: this.getYears(),
+    });
+    this.$('select').material_select();
+    this.getChildIds();
+  },
+  getYears: function(){
+        var tempInp = this.get('inputs');
+        for(var x = 0; x < tempInp.length; x++){
+          if(tempInp[x].isDate){
+            return tempInp[x].years;
+          }
+        }
+      },
+
+  getChildIds: function(){
+    var Index = 0, temp = this.get('inputs');
+    this.$('input').each(function(){
+      if(typeof(Ember.$(this).parent().attr("class")) !== 'undefined'){
+      if(Ember.$(this).parent().attr("class").indexOf("switch") === -1 && Ember.$(this).parent().attr("class").indexOf("range-field") === -1){
+        temp[Index].id = Ember.$(this).attr('id');
+        Ember.$("<label for=\"" + temp[Index].id + "\">" + temp[Index].input + "</label>").insertAfter(Ember.$(this));
+      }
+      }
+      Index++;
+    });
+    this.set('inputs', temp);
+  }
+});

--- a/app/templates/components/materialize-form.hbs
+++ b/app/templates/components/materialize-form.hbs
@@ -1,0 +1,48 @@
+{{yield}}
+{{#each I in inputs}}
+  {{#if I.isText}}
+    <div class="input-field">
+      {{input type="text"}}
+    </div>
+  {{/if}}
+  {{#if I.isRadio}}
+    <p class="radio">
+      {{input name="group1" type="radio"}}
+    </p>
+  {{/if}}
+  {{#if I.isCheckBox}}
+    <p class="checkbox">
+      {{input type="checkbox"}}
+    </p>
+  {{/if}}
+  {{#if I.isSwitch}}
+    <div class="switch">
+      <p>{{I.input}}</p>
+      <label>
+        {{I.off}}
+        {{input type="checkbox"}}
+        <span class="lever"></span>
+        {{I.on}}
+      </label>
+    </div>
+  {{/if}}
+  {{#if I.isRange}}
+    <p>{{I.input}}</p>
+    <p class="range-field">
+      {{input type="range" min="0" max="100"}}
+    </p>
+  {{/if}}
+  {{#if I.isDate}}
+    {{input type="date" class="datepicker"}}
+  {{/if}}
+  {{#if I.isSelect}}
+   <br>
+  <select>
+    <option value="" disabled selected>Choose your option</option>
+    {{#each op in I.selections}}
+    <option {{bind-attr value=op.value}}>{{op.option}}</option>
+    {{/each}}
+  </select>
+  {{/if}}
+{{/each}}
+

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -8,6 +8,7 @@ var Router = Ember.Router.extend({
 Router.map(function() {
   this.route("buttons");
   this.route("navbar");
+  this.route('forms');
 });
 
 export default Router;

--- a/tests/dummy/app/templates/forms.hbs
+++ b/tests/dummy/app/templates/forms.hbs
@@ -1,0 +1,72 @@
+<div class="section index-banner">
+  <div class="container">
+    <div class="row">
+      <div class="col s12 m9">
+        <h1 class="header">Forms</h1>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class='container'>
+  <div class='section'>
+    <div class="intro">
+      <h4 class="col s12 header">This form is in development phase:</h4>
+      <ul>
+        <li>You can include all materialize input types other than the icon prefix.</li>
+        <li>Accepts an Object array as a parameter.</li>
+        <li>The datepicker seems buggy and doesn't go back before 2000</li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<div class='container'>
+  <div class='section'>
+    <div class="intro">
+      <div class="col s12">
+        {{materialize-form}}
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class='container'>
+  <div class='section'>
+    <div class="intro">
+      <h4 class="col s12 header">Usage:</h4>
+      <ul>
+        <li>&#123;&#123;materialize-form inputs=objArray}}</li>
+        <li>objArray should have properties such as input: "First Name".<li>
+        <li>objArray should have boolean properties to tell it what kind of field such as isText: true</li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+
+<div class='container'>
+  <div class='section'>
+    <div class="intro">
+      <h4 class="col s12 header">Example usage:</h4>
+      <p>To create a form with only text fields your object would have an inputs parameter
+         that looks like <span class='grey'>inputs: [{input: "First Name", isText: true}, {input: "Last Name", isText: true}]</span></p>
+      <h4 class="col s12 header">Supported booleans</h4>
+      <ul> 
+        <li><strong>isText</strong>: for a text field.</li>
+        <li><strong>isRadio</strong>: for a radio field.</li>
+        <li><strong>isCheckBox</strong>: for a checkbox field.</li>
+        <li><strong>isSwitch</strong>: for a switch button.</li>
+        <li><strong>isRange</strong>: for a range field.</li>
+        <li><strong>isSelect</strong>: for a selec field.</li>
+      </ul>
+      <h4 class="col s12 header">Select fields:</h4>
+      <p>In addition to the normal expected values in an object such as input and isSelect the 
+      select field also expects an additional array called selections. Example declaration of a select
+      field is below.</p>
+      <p>{inputs: [{input: "What would you rather eat?", isSelect: true, selections: [{value: 1, option: "BBQ"}, {value: 2, option: "Italian"},
+      {value: 3, option: "Burgers"}]}]}
+    </div>
+  </div>
+</div>
+

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -15,6 +15,7 @@
     </div>
   </div>
 </div>
+<!-- -->
 
 <div class='container'>
   <h2 class="col s12 header">Main features</h2>
@@ -32,6 +33,7 @@
     <ul class="collection">
       {{#link-to 'buttons' class="collection-item"}}Buttons<span class="badge">6</span>{{/link-to}}
       {{#link-to 'navbar' class="collection-item"}}Navbar<span class="new badge">1</span>{{/link-to}}
+      {{#link-to 'forms' class="collection-item"}}Forms (in dev)<span class="new badge">1</span>{{/link-to}}
     </ul>
   </div>
 

--- a/tests/unit/components/materialize-form-test.js
+++ b/tests/unit/components/materialize-form-test.js
@@ -1,0 +1,21 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('materialize-form', 'MaterializeFormComponent', {
+  // specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function() {
+  expect(2);
+
+  // creates the component instance
+  var component = this.subject();
+  equal(component._state, 'preRender');
+
+  // appends the component to the page
+  this.append();
+  equal(component._state, 'inDOM');
+});


### PR DESCRIPTION
Added a form component for using materialize forms. More functionality to come soon. Demo of the form is available on the dummy routes documentation. Basicly clone the page, install ember, server the page then visit localhost:4200 and you will see the link to the forms page with a working example and documentation on how to use it. I.E. What kind of objects this component expects you to give it.